### PR TITLE
ci: use nodejs-12 runner

### DIFF
--- a/.github/workflows/dotnet-verify.yml
+++ b/.github/workflows/dotnet-verify.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   test:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/js-verify.yml
+++ b/.github/workflows/js-verify.yml
@@ -19,17 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-#      - name: Setup Node
-#        uses: actions/setup-node@v1
-#        with:
-#          node-version: ${{ env.NODE_VERSION }}
-#      - name: install yarn
-#        run: npm install -g yarn
-
       - run: |
-#          echo $SHELL
-#          nvm --version
-#          node --version
           yarn
           yarn coverage
           bash <(curl -s https://codecov.io/bash)
@@ -42,14 +32,6 @@ jobs:
       - uses: actions/checkout@v2 # create-pull-request requires v2
         with:
           ref: ${{ github.head_ref }}
-
-#      - name: Setup Node
-#        uses: actions/setup-node@v1
-#        with:
-#          node-version: ${{ env.NODE_VERSION }}
-
-#      - name: install yarn
-#        run: npm install -g yarn
 
       - run: |
           yarn

--- a/.github/workflows/js-verify.yml
+++ b/.github/workflows/js-verify.yml
@@ -13,7 +13,9 @@ env:
 
 jobs:
   test:
-    runs-on: self-hosted
+    runs-on:
+      - self-hosted
+      - nodejs-12
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/js-verify.yml
+++ b/.github/workflows/js-verify.yml
@@ -27,27 +27,29 @@ jobs:
 #        run: npm install -g yarn
 
       - run: |
-          echo $SHELL
-          nvm --version
-          node --version
+#          echo $SHELL
+#          nvm --version
+#          node --version
           yarn
           yarn coverage
           bash <(curl -s https://codecov.io/bash)
         shell: bash
   lint:
-    runs-on: self-hosted
+    runs-on:
+      - self-hosted
+      - nodejs-12
     steps:
       - uses: actions/checkout@v2 # create-pull-request requires v2
         with:
           ref: ${{ github.head_ref }}
 
-      - name: Setup Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ env.NODE_VERSION }}
+#      - name: Setup Node
+#        uses: actions/setup-node@v1
+#        with:
+#          node-version: ${{ env.NODE_VERSION }}
 
-      - name: install yarn
-        run: npm install -g yarn
+#      - name: install yarn
+#        run: npm install -g yarn
 
       - run: |
           yarn

--- a/.github/workflows/js-verify.yml
+++ b/.github/workflows/js-verify.yml
@@ -31,6 +31,7 @@ jobs:
           yarn
           yarn coverage
           bash <(curl -s https://codecov.io/bash)
+        shell: bash
   lint:
     runs-on: self-hosted
     steps:

--- a/.github/workflows/js-verify.yml
+++ b/.github/workflows/js-verify.yml
@@ -25,6 +25,7 @@ jobs:
 #        run: npm install -g yarn
 
       - run: |
+          echo $SHELL
           yarn
           yarn coverage
           bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/js-verify.yml
+++ b/.github/workflows/js-verify.yml
@@ -26,6 +26,8 @@ jobs:
 
       - run: |
           echo $SHELL
+          nvm --version
+          node --version
           yarn
           yarn coverage
           bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/js-verify.yml
+++ b/.github/workflows/js-verify.yml
@@ -17,12 +17,12 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Setup Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-      - name: install yarn
-        run: npm install -g yarn
+#      - name: Setup Node
+#        uses: actions/setup-node@v1
+#        with:
+#          node-version: ${{ env.NODE_VERSION }}
+#      - name: install yarn
+#        run: npm install -g yarn
 
       - run: |
           yarn


### PR DESCRIPTION
This also switches the dotnet commands back to hosted. Will have a separate runner for those in a separate PR.